### PR TITLE
Fix: 포트폴리오 Array로 요청 받고 응답하기

### DIFF
--- a/src/modules/portfolio/controller/portfolio.controller.ts
+++ b/src/modules/portfolio/controller/portfolio.controller.ts
@@ -59,6 +59,10 @@ export class PortfolioController {
   @Put(':portfolioid')
   @Auth(Role.Admin)
   @ApiOperation({ summary: '특정 포트폴리오 수정' })
+  @ApiOkResponse({
+    description: 'affected는 변경된 row의 갯수',
+    type: PortfolioDeleteResponseDto,
+  })
   @ApiConsumes('multipart/form-data')
   @ApiMultiFile()
   @UseInterceptors(AnyFilesInterceptor())

--- a/src/modules/portfolio/dto/create-portfolio.dto.ts
+++ b/src/modules/portfolio/dto/create-portfolio.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsJSON, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class PortfolioControllerDto {
   @IsNotEmpty()
@@ -13,13 +13,14 @@ export class PortfolioControllerDto {
   readonly teamName: string;
 
   @IsNotEmpty()
-  @IsJSON()
+  @IsArray()
   @ApiProperty({
     example: `["신성환","정유진","강동하","송은우","이한나","이재준"]`,
     description: '멤버',
     required: true,
+    isArray: true,
   })
-  readonly teamMembers: string;
+  readonly teamMembers: string[];
 
   @IsNotEmpty()
   @IsString()
@@ -40,13 +41,14 @@ export class PortfolioControllerDto {
   readonly projectDescription: string;
 
   @IsNotEmpty()
-  @IsJSON()
+  @IsArray()
   @ApiProperty({
     example: `["React","Spring","Nest.js"]`,
     description: '프레임워크 종류',
     required: true,
+    isArray: true,
   })
-  readonly frameworks: string;
+  readonly frameworks: string[];
 }
 
 export class PortfolioCreateDto extends PortfolioControllerDto {

--- a/src/modules/portfolio/dto/reponse-portfolio.dto.ts
+++ b/src/modules/portfolio/dto/reponse-portfolio.dto.ts
@@ -15,11 +15,14 @@ export class PortfolioGetResponseDto extends PortfolioControllerDto {
     description: '이미지 URL',
     example: `[\"https://pg-renewal-portfolio-images.s3.ap-northeast-2.amazonaws.com/portfolio_images/1667202502511103241850.png\"]`,
   })
-  imageUrl: string;
+  imageUrl: string[];
   generation: PortfolioGenerationDto;
 }
 
-export class PortfolioPutResponseDto extends PortfolioGetResponseDto {}
+export class PortfolioPutResponseDto {
+  @ApiProperty({ description: '변경된 row 갯수', example: '1' })
+  affected: number;
+}
 
 export class PortfolioDeleteResponseDto {
   @ApiProperty({ description: '변경된 row 갯수', example: '1' })

--- a/src/modules/portfolio/repository/portfolio.repository.ts
+++ b/src/modules/portfolio/repository/portfolio.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Generations } from 'src/infra/entity/Generations.entity';
 import { Portfolios } from 'src/infra/entity/Portpolios.entity';
-import { DeleteResult, Equal, Repository } from 'typeorm';
+import { DeleteResult, Equal, Repository, UpdateResult } from 'typeorm';
 
 export type PortfolioRepositoryDto = {
   imageUrl: string;
@@ -67,8 +67,10 @@ export class PortfolioRepository {
   async updateOneById(
     id: number,
     portfolioData: PortfolioRepositoryDto,
-  ): Promise<Portfolios> {
-    return await this.portfolioRepository.save({ id, portfolioData });
+  ): Promise<UpdateResult> {
+    return await this.portfolioRepository.update(id, {
+      ...portfolioData,
+    });
   }
 
   async deleteOneById(portfolioId: number): Promise<DeleteResult> {


### PR DESCRIPTION
## 작업내용
- 응답시 String 형태로 반환되던 데이터 Object 형태로 변경하기
- 요청시 String 형태가 아닌 Array 형태로 입력 받을 수 있도록 하기
- portfolio update시 변경된 row 수 반환 형태로 변경
## 주의사항
- 현재까지 확인된 curl 정보
```
curl --location --request POST 'http://localhost:3000/api/portfolios' \
--header 'Authorization: Bearer' \
--form 'teamName="test"' \
--form 'teamMembers[]="1번 배열"' \
--form 'teamMembers[]="2번 배열"' \
--form 'projectName="test"' \
--form 'projectDescription="test"' \
--form 'frameworks[]="3번 배열"' \
--form 'frameworks[]="4번 배열"' \
--form 'generationId="7"' \
--form 'files=@"/Users/logo.png"'
```