### PR TITLE
Fix: .platform 인식문제로 .ebextension폴더 생성

### DIFF
--- a/.ebextensions/set_limit_size.config
+++ b/.ebextensions/set_limit_size.config
@@ -1,0 +1,4 @@
+files:
+  "/etc/nginx/conf.d/proxy.conf":
+     content: |
+       client_max_body_size 100M;


### PR DESCRIPTION
## 작업내용
- .platform 으로 nginx 설정을 변경해보려 했으나 실패
- .ebextensions로 폴더를 생성하여 진행
- 두 폴더의 차이는 AWS EB의 Linux 버전이 1과 2의 차이라고함